### PR TITLE
enable error report for Proxy.register

### DIFF
--- a/lib/host.ts
+++ b/lib/host.ts
@@ -207,15 +207,11 @@ export class Proxy implements Host {
             throw Error("HostProxy cannot register application for a different zone.");
         }
 
-        this._zone.broadcast((baseDir: string, appModulePath: string, instanceNames: string[]) => {
+        this._zone.broadcastSync((baseDir: string, appModulePath: string, instanceNames: string[]) => {
                 require(baseDir + '/index').hub().register(appModulePath, instanceNames);
-            }, [__dirname, appModulePath, appInstanceNames])
-            .then(() => {
-                this._applicationInstanceNames = this._applicationInstanceNames.concat(appInstanceNames);
-            })
-            .catch((e) => {
-                throw e;
-            });
+            }, [__dirname, appModulePath, appInstanceNames]);
+
+        this._applicationInstanceNames = this._applicationInstanceNames.concat(appInstanceNames);
     }
 
     /// <summary> Serve a request. </summary>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "types": "./types/index.d.ts",
     "readme": "./README.md",
     "dependencies": {
-        "napajs": "^0.2.0",
+        "napajs": "^0.2.2",
         "strip-json-comments": "^2.0.0"
     },
     "devDependencies": {

--- a/test/host-test.ts
+++ b/test/host-test.ts
@@ -137,20 +137,21 @@ describe('winery/host', () => {
                 ["testApp"]);
         }).timeout(0);
 
-        // Bug: https://github.com/Microsoft/napajs/issues/158 
-        // Broadcast will succeed even register will fail.
-        it.skip('#register: fail - duplicated instance name', (done) => {
-            host.register(
-                path.resolve(__dirname, './test-app'),
-                ["testApp"]);
+        it('#register: fail - duplicated instance name', () => {
+            assert.throws(() => {
+                host.register(
+                    path.resolve(__dirname, './test-app'),
+                    ["testApp"]);
+            });
         });
             
-        // Bug: Broadcast shall support synchronized version.
-        it.skip('#register: fail - register for another container.', (done) => {
-            host.register(
-                path.resolve(__dirname, './test-app'), 
-                ["testApp"], 
-                napa.zone.create('zone3'));
+        it('#register: fail - register for another container.', () => {
+            assert.throws(() => {
+                host.register(
+                    path.resolve(__dirname, './test-app'), 
+                    ["testApp"], 
+                    napa.zone.create('zone3'));
+            });
         });
 
         it('#serve: sync entrypoint', (done) => {


### PR DESCRIPTION
Napa.js 0.2.2 introduced new API `zone.broadcastSync()`, which allows `Proxy.register` to report error.

Fixes #3 and #4.