### PR TITLE
Remove before_install stage in CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ compiler: default
 node_js: 
   - '8'
 
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -q
-  - sudo apt-get upgrade
-  - sudo apt-get dist-upgrade
-
 install:
   - npm install
 


### PR DESCRIPTION
The current CI build script does a full package upgrade in stage `before_install`, which is unnecessary.